### PR TITLE
Build jupyter-book without conda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,20 +23,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v2
-    - name: Cache
-      uses: actions/cache@v1
-      env:
-        # Increase this value to reset cache
-        CACHE_NUMBER: 0
-      with:
-        path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        activate-environment: fugue-docs
-        mamba-version: "*"
-        environment-file: environment.yml
-        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+    - name: Install jupyter-book
+      run: pip install jupyter-book
 
     # Build the book
     - name: Build the book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # Trigger the workflow on push to main branch
   push:
     branches:
-      - master
+      - build-jbook-without-conda
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:


### PR DESCRIPTION
As jupyter-book doesn't have to execute cells as ipynb
is being used as the workhorse file format the fugue-tutorials
dependencies are no longer required to build the book!

This massively speeds up deployments