### PR TITLE
Remove header-only README tables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v2
     - name: Install jupyter-book
-      run: pip install jupyter-book==0.11.3
+      run: pip install jupyter-book
 
     # Build the book
     - name: Build the book

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://join.slack.com/t/fugue-project/shared_invite/zt-jl0pcahu-KdlSOgi~fP50TZWmNxdWYQ) ⬅️ Chat with us on slack
 
-| ⚠️ Please notice that running the code is slow on binder as the spark initialization can take a long time! |
-|---------------------------------------------------------------------------------------------------------------|
+> ⚠️ Please notice that running the code is slow on binder as the spark initialization can take a long time!
 
 ## Running locally
 
@@ -17,5 +16,4 @@ To run the tutorials environment on your own machine, the simplest way is via do
 docker run -p 8888:8888 fugueproject/tutorials:latest
 ```
 
-| 🚀 The performance should be better running docker on your own machine |
-|-------------------------------------------------------------------------|
+> 🚀 The performance should be better running docker on your own machine


### PR DESCRIPTION
Enables use of jupyter-book 0.12.0 which otherwise
breaks on header-only tables

See https://github.com/fugue-project/tutorials/issues/101