### PR TITLE
Add infer_schema to FugueSQL LOAD operators

### DIFF
--- a/tutorials/fugue_sql/operators.ipynb
+++ b/tutorials/fugue_sql/operators.ipynb
@@ -179,7 +179,9 @@
     "\n",
     "* PARQUET|CSV|JSON - File type to load. Required if the file has no extension\n",
     "* path - File path to load\n",
-    "* params - Passed on to underlying execution engine loading method\n",
+    "* params\n",
+    "  * infer_schema - should `fugue` infer the schema, true or false\n",
+    "  * remaining arguments are passed on to underlying execution engine loading method\n",
     "* COLUMNS - Columns to grab or schema to load it in as"
    ]
   },

--- a/tutorials/fugue_sql/operators.ipynb
+++ b/tutorials/fugue_sql/operators.ipynb
@@ -180,7 +180,7 @@
     "* PARQUET|CSV|JSON - File type to load. Required if the file has no extension\n",
     "* path - File path to load\n",
     "* params\n",
-    "  * infer_schema - should `fugue` infer the schema, true or false\n",
+    "  * infer_schema - infer the schema, true or false\n",
     "  * remaining arguments are passed on to underlying execution engine loading method\n",
     "* COLUMNS - Columns to grab or schema to load it in as"
    ]


### PR DESCRIPTION
I just realised that this one isn't documented.  It looks like `fugue` overrides the execution engine params for this one particular arg.  @kvnkho can you think of any others?