### PR TITLE
Add Scipy Tune demo notebooks

### DIFF
--- a/tutorials/tune/SciPyDemo_2_CA_Housing.ipynb
+++ b/tutorials/tune/SciPyDemo_2_CA_Housing.ipynb
@@ -1,0 +1,279 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cd9b361c-9f74-447c-a852-e0ea06984974",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7679064d642b438dac432a93e2f82d68",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:error sending AWS credentials to cluster: Connect timeout on endpoint URL: \"http://169.254.169.254/latest/api/token\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fugue_coiled import CoiledDaskClient\n",
+    "\n",
+    "client = CoiledDaskClient(n_workers=8, software=\"fugue-env\", environ={\"WANDB_START_METHOD\":\"thread\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af63c1f9-4526-497c-90c1-5c7671b0b406",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# client.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "31a8ace1-9903-4c2a-8ccb-2451bf0f58aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[       MedInc  HouseAge  AveRooms  AveBedrms  Population  AveOccup  Latitude  \\\n",
+       " 12069  4.2386       6.0  7.723077   1.169231       228.0  3.507692     33.83   \n",
+       " 15925  4.3898      52.0  5.326622   1.100671      1485.0  3.322148     37.73   \n",
+       " 11162  3.9333      26.0  4.668478   1.046196      1022.0  2.777174     33.83   \n",
+       " 4904   1.4653      38.0  3.383495   1.009709       749.0  3.635922     34.01   \n",
+       " 4683   3.1765      52.0  4.119792   1.043403      1135.0  1.970486     34.08   \n",
+       " ...       ...       ...       ...        ...         ...       ...       ...   \n",
+       " 13123  4.4125      20.0  6.000000   1.045662       712.0  3.251142     38.27   \n",
+       " 19648  2.9135      27.0  5.349282   0.933014       647.0  3.095694     37.48   \n",
+       " 9845   3.1977      31.0  3.641221   0.941476       704.0  1.791349     36.58   \n",
+       " 10799  5.6315      34.0  4.540598   1.064103      1052.0  2.247863     33.62   \n",
+       " 2732   1.3882      15.0  3.929530   1.100671      1024.0  3.436242     32.80   \n",
+       " \n",
+       "        Longitude   target  \n",
+       " 12069    -117.55  5.00001  \n",
+       " 15925    -122.44  2.70000  \n",
+       " 11162    -118.00  1.96100  \n",
+       " 4904     -118.26  1.18800  \n",
+       " 4683     -118.36  2.25000  \n",
+       " ...          ...      ...  \n",
+       " 13123    -121.26  1.44600  \n",
+       " 19648    -120.89  1.59400  \n",
+       " 9845     -121.90  2.89300  \n",
+       " 10799    -117.93  4.84600  \n",
+       " 2732     -115.56  0.69400  \n",
+       " \n",
+       " [16512 rows x 9 columns],\n",
+       "        MedInc  HouseAge  AveRooms  AveBedrms  Population  AveOccup  Latitude  \\\n",
+       " 14740  4.1518      22.0  5.663073   1.075472      1551.0  4.180593     32.58   \n",
+       " 10101  5.7796      32.0  6.107226   0.927739      1296.0  3.020979     33.92   \n",
+       " 20566  4.3487      29.0  5.930712   1.026217      1554.0  2.910112     38.65   \n",
+       " 2670   2.4511      37.0  4.992958   1.316901       390.0  2.746479     33.20   \n",
+       " 15709  5.0049      25.0  4.319261   1.039578       649.0  1.712401     37.79   \n",
+       " ...       ...       ...       ...        ...         ...       ...       ...   \n",
+       " 6655   2.4817      33.0  3.875723   1.034682      2050.0  2.962428     34.16   \n",
+       " 3505   4.3839      36.0  5.283636   0.981818       808.0  2.938182     34.25   \n",
+       " 1919   3.2027      11.0  5.276074   1.058282       850.0  2.607362     38.86   \n",
+       " 1450   6.1436      18.0  7.323529   1.050802      1072.0  2.866310     37.96   \n",
+       " 4148   3.3326      52.0  3.891626   1.049261      1462.0  3.600985     34.12   \n",
+       " \n",
+       "        Longitude  target  \n",
+       " 14740    -117.05   1.369  \n",
+       " 10101    -117.97   2.413  \n",
+       " 20566    -121.84   2.007  \n",
+       " 2670     -115.60   0.725  \n",
+       " 15709    -122.43   4.600  \n",
+       " ...          ...     ...  \n",
+       " 6655     -118.13   1.695  \n",
+       " 3505     -118.45   2.046  \n",
+       " 1919     -120.92   1.286  \n",
+       " 1450     -121.95   2.595  \n",
+       " 4148     -118.20   1.676  \n",
+       " \n",
+       " [4128 rows x 9 columns]]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from typing import Tuple, Dict, Any\n",
+    "from tune import Space, RandInt, Grid\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "from sklearn.metrics import mean_absolute_percentage_error, make_scorer\n",
+    "from sklearn.datasets import fetch_california_housing, load_diabetes\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "def get_housing(func:callable):\n",
+    "    data = func(as_frame=True)\n",
+    "    return train_test_split(data[\"data\"].assign(target=data[\"target\"]), test_size=0.2, random_state=0)\n",
+    "    \n",
+    "get_housing(fetch_california_housing)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95d055e6-4126-4b20-ba8c-b7553a5f56d9",
+   "metadata": {},
+   "source": [
+    "# Define Objective Function and Search Space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3dec782c-1dc2-4e98-bae9-d20065592df8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightgbm import LGBMRegressor\n",
+    "from xgboost import XGBRegressor\n",
+    "\n",
+    "# get training data\n",
+    "train, _ = get_housing(fetch_california_housing)\n",
+    "\n",
+    "# define objective function\n",
+    "def objective(model:Any, **hp:Any) -> float:\n",
+    "    model_ins = model(**hp)\n",
+    "    x = train.iloc[:,:-1]\n",
+    "    y = train.iloc[:,-1]\n",
+    "    scores = cross_val_score(model_ins, x, y, cv=3, \n",
+    "                             scoring=make_scorer(mean_absolute_percentage_error))\n",
+    "    return scores.mean()\n",
+    "\n",
+    "# define search spaces\n",
+    "xgb_space = Space(model=XGBRegressor, n_estimators=Grid(100, 200, 300))\n",
+    "lgbm_space = Space(model=LGBMRegressor, n_estimators=RandInt(100, 300))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c7d648d4-a379-4af8-b4ca-6967831b178d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGB Baseline: 0.18111303006212223\n",
+      "LGBM Baseline 0.17842243141239011\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get baseline scores\n",
+    "print(\"XGB Baseline:\", objective(XGBRegressor))\n",
+    "print(\"LGBM Baseline\", objective(LGBMRegressor))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c04409bd-5917-48f9-895a-445fbe725472",
+   "metadata": {},
+   "source": [
+    "# Tuning\n",
+    "\n",
+    "1. Evaluate the objective function\n",
+    "2. Over a hybrid search space\n",
+    "3. Apply Hyperopt for Bayesian Optimization \n",
+    "4. Run tuning jobs distributedly on Dask\n",
+    "5. Track tuning result with wandb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d06fe31f-a2ad-429b-b468-7c98f745de1d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m If you're specifying your api key in code, ensure this code is not shared publicly.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m Consider setting the WANDB_API_KEY environment variable, or running `wandb login` from the command line.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Appending key for api.wandb.ai to your netrc file: /home/jovyan/.netrc\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m If you're specifying your api key in code, ensure this code is not shared publicly.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m Consider setting the WANDB_API_KEY environment variable, or running `wandb login` from the command line.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Appending key for api.wandb.ai to your netrc file: /home/jovyan/.netrc\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m If you're specifying your api key in code, ensure this code is not shared publicly.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m Consider setting the WANDB_API_KEY environment variable, or running `wandb login` from the command line.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Appending key for api.wandb.ai to your netrc file: /home/jovyan/.netrc\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tune import suggest_for_noniterative_objective\n",
+    "\n",
+    "result = suggest_for_noniterative_objective(\n",
+    "    objective,\n",
+    "    xgb_space + lgbm_space,\n",
+    "    local_optimizer = \"hyperopt:5\",\n",
+    "    execution_engine = client,\n",
+    "    logger = \"wandb:CA_housing_tuning_scipy\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "275650ce-566a-44f6-a71f-55dfe2f58eec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result[0]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/tune/SciPyDemo_3_GreyKite.ipynb
+++ b/tutorials/tune/SciPyDemo_3_GreyKite.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "437b80dd-226d-4d44-b9ae-54295705f219",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import coiled\n",
+    "\n",
+    "cluster = coiled.Cluster(name=\"han-wang-1e3d51eb-8\", software=\"fugue-env\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e600105f-59d4-49c6-a28b-d7c034e11753",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import datetime\n",
+    "\n",
+    "from typing import Dict, Any, Tuple\n",
+    "from copy import deepcopy\n",
+    "\n",
+    "# greykite configs\n",
+    "from greykite.algo.changepoint.adalasso.changepoint_detector import ChangepointDetector\n",
+    "from greykite.algo.forecast.silverkite.constants.silverkite_holiday import SilverkiteHoliday\n",
+    "from greykite.algo.forecast.silverkite.constants.silverkite_seasonality import SilverkiteSeasonalityEnum\n",
+    "from greykite.algo.forecast.silverkite.forecast_simple_silverkite_helper import cols_interact\n",
+    "from greykite.common import constants as cst\n",
+    "from greykite.common.features.timeseries_features import build_time_features_df\n",
+    "from greykite.common.features.timeseries_features import convert_date_to_continuous_time\n",
+    "from greykite.framework.benchmark.data_loader_ts import DataLoaderTS\n",
+    "from greykite.framework.templates.autogen.forecast_config import EvaluationPeriodParam\n",
+    "from greykite.framework.templates.autogen.forecast_config import ForecastConfig\n",
+    "from greykite.framework.templates.autogen.forecast_config import MetadataParam\n",
+    "from greykite.framework.templates.autogen.forecast_config import ModelComponentsParam\n",
+    "from greykite.framework.templates.forecaster import Forecaster\n",
+    "from greykite.framework.templates.model_templates import ModelTemplateEnum\n",
+    "from greykite.framework.utils.result_summary import summarize_grid_search_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e52ffe8-b80d-46df-b4e7-178bfafd06a2",
+   "metadata": {},
+   "source": [
+    "# Define Objective Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c06c7cc-404d-42a0-95d0-4a62abf2c18a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def objective(**gkparams) -> float:\n",
+    "    dl = DataLoaderTS()\n",
+    "    ts = dl.load_peyton_manning_ts()\n",
+    "    df_full = ts.make_future_dataframe(periods=365)\n",
+    "    df_features = build_time_features_df(\n",
+    "     dt=df_full[\"ts\"],\n",
+    "     conti_year_origin=convert_date_to_continuous_time(df_full[\"ts\"][0])\n",
+    "    )\n",
+    "    is_football_season = (df_features[\"woy\"] <= 6) | (df_features[\"woy\"] >= 36)\n",
+    "    df_full[\"is_football_season\"] = is_football_season.astype(int).tolist()\n",
+    "    df_full.reset_index(drop=True, inplace=True)\n",
+    "    \n",
+    "    anomaly_df = pd.DataFrame({\n",
+    "        # start and end date are inclusive\n",
+    "        # each row is an anomaly interval\n",
+    "        cst.START_DATE_COL: [\"2010-06-05\", \"2012-03-01\"],  # inclusive\n",
+    "        cst.END_DATE_COL: [\"2010-06-20\", \"2012-03-20\"],  # inclusive\n",
+    "        cst.ADJUSTMENT_DELTA_COL: [np.nan, np.nan],  # mask as NA\n",
+    "    })\n",
+    "\n",
+    "    # Creates anomaly_info dictionary.\n",
+    "    # This will be fed into the template.\n",
+    "    anomaly_info = {\n",
+    "        \"value_col\": \"y\",\n",
+    "        \"anomaly_df\": anomaly_df,\n",
+    "        \"adjustment_delta_col\": cst.ADJUSTMENT_DELTA_COL,\n",
+    "    }\n",
+    "\n",
+    "    # Specifies dataset information\n",
+    "    metadata = MetadataParam(\n",
+    "        time_col=\"ts\",  # name of the time column\n",
+    "        value_col=\"y\",  # name of the value column\n",
+    "        freq=\"D\",  # \"H\" for hourly, \"D\" for daily, \"W\" for weekly, etc.\n",
+    "        anomaly_info=anomaly_info,  # this is the anomaly information we defined above,\n",
+    "        train_end_date=datetime.datetime(2016, 1, 20)\n",
+    "    )\n",
+    "\n",
+    "    # Defines the cross-validation config\n",
+    "    evaluation_period = EvaluationPeriodParam(\n",
+    "        test_horizon=365,             # leaves 365 days as testing data\n",
+    "        cv_horizon=365,               # each cv test size is 365 days (same as forecast horizon)\n",
+    "        cv_max_splits=3,              # 3 folds cv\n",
+    "        cv_min_train_periods=365 * 4  # uses at least 4 years for training because we have 8 years data\n",
+    "    )\n",
+    "\n",
+    "    model_components = ModelComponentsParam(**gkparams)\n",
+    "    \n",
+    "    try:\n",
+    "    \n",
+    "        forecaster = Forecaster()\n",
+    "        # Runs the forecast\n",
+    "        run = forecaster.run_forecast_config(\n",
+    "         df=df_full,\n",
+    "         config=ForecastConfig(\n",
+    "             model_template=ModelTemplateEnum.SILVERKITE.name,\n",
+    "             model_components_param=model_components,\n",
+    "             forecast_horizon=365,  # forecasts 365 steps ahead\n",
+    "             coverage=0.95,  # 95% prediction intervals\n",
+    "             metadata_param=metadata,\n",
+    "             evaluation_period_param=evaluation_period\n",
+    "         )\n",
+    "        )\n",
+    "\n",
+    "        result = summarize_grid_search_results(\n",
+    "            grid_search=run.grid_search,\n",
+    "            column_order = [\"mean_test\"]\n",
+    "        ).to_dict(\"records\")[0]\n",
+    "\n",
+    "        return result[\"mean_test_MAPE\"]\n",
+    "    except:\n",
+    "        return 10000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "141634c1-41d8-4bb7-8674-4df504c8dd81",
+   "metadata": {},
+   "source": [
+    "# Define a Hybrid Search Space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07c59a1a-9513-412b-aeac-3364364f5953",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from tune import Space, Grid, Rand, RandInt, Choice, TransitionChoice, FuncParam\n",
+    "\n",
+    "weekly_seasonality = RandInt(0,8)\n",
+    "yearly_seasonality = RandInt(0,50)\n",
+    "\n",
+    "space = Space(\n",
+    "    seasonality = {\n",
+    "        \"yearly_seasonality\": yearly_seasonality,\n",
+    "        \"quarterly_seasonality\": RandInt(0,10),\n",
+    "        \"monthly_seasonality\": RandInt(0,10),\n",
+    "        \"weekly_seasonality\": weekly_seasonality,\n",
+    "    },\n",
+    "    changepoints = {\n",
+    "        \"changepoints_dict\": dict(\n",
+    "            method=\"auto\",\n",
+    "            yearly_seasonality_order=yearly_seasonality,\n",
+    "            regularization_strength=Rand(0.6,0.8),\n",
+    "            resample_freq=TransitionChoice(*[f\"{x}D\" for x in range(1,32)]),\n",
+    "            potential_changepoint_n=RandInt(10,200),\n",
+    "            no_changepoint_distance_from_end=TransitionChoice(*[f\"{x}D\" for x in range(91,365)])\n",
+    "        )\n",
+    "    },\n",
+    "    events = {\n",
+    "        \"holidays_to_model_separately\": SilverkiteHoliday.ALL_HOLIDAYS_IN_COUNTRIES,\n",
+    "        \"holiday_lookup_countries\": [\"UnitedStates\"],\n",
+    "        \"holiday_pre_num_days\": Grid(0,1,2,3,4,5),\n",
+    "        \"holiday_post_num_days\": Grid(0,1,2,3,4,5),\n",
+    "        \"daily_event_df_dict\": {\n",
+    "            \"superbowl\": pd.DataFrame({\n",
+    "                \"date\": [\"2008-02-03\", \"2009-02-01\", \"2010-02-07\", \"2011-02-06\",\n",
+    "                      \"2012-02-05\", \"2013-02-03\", \"2014-02-02\", \"2015-02-01\", \"2016-02-07\"],\n",
+    "            \"event_name\": [\"event\"] * 9\n",
+    "        })\n",
+    "     }\n",
+    "    },\n",
+    "    custom = {\n",
+    "        \"fit_algorithm_dict\": Grid(\n",
+    "            {\"fit_algorithm\": \"ridge\"},\n",
+    "            {\"fit_algorithm\": \"linear\", \"fit_algorithm_params\": dict(missing=\"drop\")}\n",
+    "        ),\n",
+    "    },\n",
+    "    regressors = {\n",
+    "        \"regressor_cols\": [\"is_football_season\"]\n",
+    "    },\n",
+    "    uncertainty={\n",
+    "        \"uncertainty_dict\": \"auto\",\n",
+    "    },\n",
+    ").sample(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54b66306-6fef-40b0-bef0-9f0f8b3f6593",
+   "metadata": {},
+   "source": [
+    "# Tuning Flow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "397dd102-8d4d-4697-9052-8d6516545863",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tune import suggest_for_noniterative_objective\n",
+    "\n",
+    "result = suggest_for_noniterative_objective(\n",
+    "    objective,\n",
+    "    space,\n",
+    "    execution_engine = cluster,\n",
+    "    logger           = \"wandb:GreyKite_tuning\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4130f2e5-14d6-412f-98d5-ce0683e333bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result[0]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/tune/ScipPyDemo_1_Space_Operation.ipynb
+++ b/tutorials/tune/ScipPyDemo_1_Space_Operation.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a70fa1c4-99ab-456f-8276-df0c713b0eab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tune import Space, Grid, Rand, RandInt, Choice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c2e2db59-8626-438b-ba16-086fa6307fa6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightgbm import LGBMRegressor\n",
+    "from xgboost import XGBRegressor\n",
+    "from catboost import CatBoostRegressor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24b9458a-0471-421b-ab7c-2e98bc7cd2d4",
+   "metadata": {},
+   "source": [
+    "# Example 1: Union Space\n",
+    "\n",
+    "`+` means take the union of the spaces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f4c1af40-1ff8-4f7f-a539-5ba9f28c5222",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'model': <class 'xgboost.sklearn.XGBRegressor'>, 'n_estimatores': 50},\n",
+       " {'model': <class 'xgboost.sklearn.XGBRegressor'>, 'n_estimatores': 150},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimatores': 100},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimatores': 146},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimatores': 148},\n",
+       " {'model': <class 'catboost.core.CatBoostRegressor'>, 'n_estimatores': RandInt(low=100, high=200, q=1, log=False, include_high=True)}]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# use case: different tuning method on different modeling algorithms\n",
+    "\n",
+    "xgb_gird = Space(model=XGBRegressor, n_estimatores=Grid(50,150))  \n",
+    "lgbm_random = Space(model=LGBMRegressor, n_estimatores=RandInt(100,200)).sample(3) \n",
+    "catboost_bo = Space(model=CatBoostRegressor, n_estimatores=RandInt(100,200))  \n",
+    "\n",
+    "union_space = xgb_gird + lgbm_random + catboost_bo # \"+\" takes the union of spaces\n",
+    "\n",
+    "list(union_space)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "070c4b71-78f1-4d64-be54-a9b5639bb848",
+   "metadata": {},
+   "source": [
+    "# Example 2: Cross Product Space\n",
+    "\n",
+    "`*` means take the cross product of the spaces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "61788320-0559-4190-a4ef-b2d9c14f0dcf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimators': 100, 'boosting': 'dart', 'feature_fraction': 0.7744067519636624, 'learning_rate': Rand(low=1e-08, high=10, q=None, log=True, include_high=True)},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimators': 100, 'boosting': 'gbdt', 'feature_fraction': 0.7744067519636624, 'learning_rate': Rand(low=1e-08, high=10, q=None, log=True, include_high=True)},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimators': 100, 'boosting': 'dart', 'feature_fraction': 0.8575946831862098, 'learning_rate': Rand(low=1e-08, high=10, q=None, log=True, include_high=True)},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimators': 100, 'boosting': 'gbdt', 'feature_fraction': 0.8575946831862098, 'learning_rate': Rand(low=1e-08, high=10, q=None, log=True, include_high=True)}]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# use case: diffferent tuning method inside one modeling algorithm\n",
+    "\n",
+    "non_bo_space = Space(\n",
+    "    model=LGBMRegressor, \n",
+    "    n_estimators=100,\n",
+    "    boosting=Grid(\"dart\", \"gbdt\"),    # Grid search\n",
+    "    feature_fraction=Rand(0.5, 1)     # Random search\n",
+    ").sample(2, seed=0) \n",
+    "\n",
+    "bo_space = Space(\n",
+    "    learning_rate=Rand(1e-8, 10, log=True)  # Bayesian Optimization\n",
+    ") \n",
+    "\n",
+    "product_space = non_bo_space * bo_space # \"+\" takes cross product of spaces\n",
+    "\n",
+    "list(product_space)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae82c2aa-aecd-4d04-953a-0090201b72d9",
+   "metadata": {},
+   "source": [
+    "# Example 3: Construct Hybrid Search Space\n",
+    "\n",
+    "Now we can use these operators to construct any combination of searching spaces as desired."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "99be1691-ad38-48cf-8523-c3830318f95c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'model': <class 'xgboost.sklearn.XGBRegressor'>, 'n_estimatores': RandInt(low=100, high=200, q=1, log=False, include_high=True)},\n",
+       " {'model': <class 'lightgbm.sklearn.LGBMRegressor'>, 'n_estimatores': RandInt(low=100, high=200, q=1, log=False, include_high=True)},\n",
+       " {'model': <class 'catboost.core.CatBoostRegressor'>, 'n_estimatores': RandInt(low=100, high=200, q=1, log=False, include_high=True)}]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# use case: any kind of hybrid search spaces\n",
+    "# e.g. tuning a common parameter on 3 modeling algorithms\n",
+    "\n",
+    "xgb_static = Space(model=XGBRegressor)\n",
+    "lgb_static = Space(model=LGBMRegressor)\n",
+    "catboost_static = Space(model=CatBoostRegressor)\n",
+    "\n",
+    "bo_space = Space(n_estimatores=RandInt(100,200)) # Bayesian Optimization on a common parameter\n",
+    "\n",
+    "hybrid_space = (xgb_static + lgb_static + catboost_static) * bo_space\n",
+    "\n",
+    "list(hybrid_space)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dec6c6c-4308-499f-b489-82de81e8f10b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef48a494-2cbc-4ea7-916b-f9cfccc9bac2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Notebooks used on Scipy 2022 talk

1. Space Operation (union, cross product, hybrid)
2. CA housing with XGBoost and LightGBM (hyperopt + dask + wandb)
3. General objective tuning with GreyKite (hyperopt + dask + wandb)