### PR TITLE
Demonstrate loading from db via pandas

### DIFF
--- a/tutorials/applications/recipes/loading_databases.ipynb
+++ b/tutorials/applications/recipes/loading_databases.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading database tables\n",
+    "\n",
+    "We can either use a custom `Creator` load from a database to a `DataFrame` or we can use the database engine service itself to output a file which  can then be loaded in `fugue`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's dump some data into a `sqlite` database & read it in `fugue`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sqlite3\n",
+    "\n",
+    "from fugue import FugueWorkflow\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_sqlite_db(path: str, content: str, table: str):\n",
+    "    uri = f\"file:{path}\"\n",
+    "    lines = content.split(\"\\n\")\n",
+    "    headers = lines[0]\n",
+    "    rows = lines[1:]\n",
+    "    with sqlite3.connect(uri, uri=True) as con:\n",
+    "        cur = con.cursor()\n",
+    "        cur.execute(f\"CREATE TABLE {table}({headers})\")\n",
+    "        values = \"(\" + '),('.join(row for row in rows) + \")\"\n",
+    "        cur.execute(f\"INSERT INTO {table} VALUES {values}\")\n",
+    "        con.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content = '''\\\n",
+    "\"TIMESTAMP\",\"RECORD\",\"WS_80m_90deg_Avg\",\"WS_80m_90deg_Std\",\"WS_80m_90deg_3sGust_Max\",\"WS_80m_90deg_Max\",\"WS_80m_270deg_Avg\",\"WS_80m_270deg_Std\",\"WS_80m_270deg_3sGust_Max\",\"WS_80m_270deg_Max\",\"WS_65m_90deg_Avg\",\"WS_65m_90deg_Std\",\"WS_65m_90deg_3sGust_Max\",\"WS_65m_90deg_Max\",\"WS_65m_270deg_Avg\",\"WS_65m_270deg_Std\",\"WS_65m_270deg_3sGust_Max\",\"WS_65m_270deg_Max\",\"WS_50m_90deg_Avg\",\"WS_50m_90deg_Std\",\"WS_50m_90deg_3sGust_Max\",\"WS_50m_90deg_Max\",\"WS_50m_270deg_Avg\",\"WS_50m_270deg_Std\",\"WS_50m_270deg_3sGust_Max\",\"WS_50m_270deg_Max\",\"WS_30m_90deg_Avg\",\"WS_30m_90deg_Std\",\"WS_30m_90deg_3sGust_Max\",\"WS_30m_90deg_Max\",\"WS_30m_270deg_Avg\",\"WS_30m_270deg_Std\",\"WS_30m_270deg_3sGust_Max\",\"WS_30m_270deg_Max\",\"Dir_78m_90deg_avg\",\"Dir_78m_90deg_std\",\"Dir_63m_90deg_avg\",\"Dir_63m_90deg_std\",\"Dir_28m_90deg_avg\",\"Dir_28m_90deg_std\",\"Batt_Volt_Min\",\"Press_Avg\",\"Temp_C80_Avg\",\"Temp_C15_Avg\",\"Hum_Avg\"\n",
+    "\"2012-05-31 12:20:00\",1,1.383,0.6,2.75,3.37,1.368,0.439,2.673,2.74,1.332,0.478,2.75,2.75,1.242,0.379,2.74,2.79,1.162,0.535,2.337,2.75,1.159,0.354,2.34,2.39,1.27,0.614,2.337,2.75,1.322,0.416,2.157,2.24,240.3,46,242,45.39,222,33.45,13.79,1009,13.84,14.08,65.67\n",
+    "\"2012-05-31 12:30:00\",2,1.183,0.449,1.923,2.13,1.135,0.324,1.94,1.99,0.948,0.524,1.923,2.13,1.068,0.303,1.723,1.74,0.701,0.547,1.923,2.13,0.913,0.308,1.673,1.74,0.771,0.539,1.717,2.13,0.997,0.28,1.657,1.74,282,26.79,264.3,30.25,278.5,62.87,13.73,1009,14.04,14.45,64.51'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_db(table: str, con: str) -> pd.DataFrame:\n",
+    "    return pd.read_sql_table(table, uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PandasDataFrame\n",
+      "TIMESTAMP:str |RECORD:long|WS_80m_90deg_Avg:double|WS_80m_90deg_Std:double|WS_80m_90deg_3sGust_Max:double|WS_80m_90deg_Max:double|WS_80m_270deg_Avg:double|WS_80m_270deg_Std:double|WS_80m_270deg_3sGust_Max:double|WS_80m_270deg_Max:double|WS_65m_90deg_Avg:double|WS_65m_90deg_Std:double|WS_65m_90deg_3sGust_Max:double|WS_65m_90deg_Max:double|WS_65m_270deg_Avg:double|WS_65m_270deg_Std:double|WS_65m_270deg_3sGust_Max:double|WS_65m_270deg_Max:double|WS_50m_90deg_Avg:double|WS_50m_90deg_Std:double|WS_50m_90deg_3sGust_Max:double|WS_50m_90deg_Max:double|WS_50m_270deg_Avg:double|WS_50m_270deg_Std:double|WS_50m_270deg_3sGust_Max:double|WS_50m_270deg_Max:double|WS_30m_90deg_Avg:double|WS_30m_90deg_Std:double|WS_30m_90deg_3sGust_Max:double|WS_30m_90deg_Max:double|WS_30m_270deg_Avg:double|WS_30m_270deg_Std:double|WS_30m_270deg_3sGust_Max:double|WS_30m_270deg_Max:double|Dir_78m_90deg_avg:double|Dir_78m_90deg_std:double|Dir_63m_90deg_avg:double|Dir_63m_90deg_std:double|Dir_28m_90deg_avg:double|Dir_28m_90deg_std:double|Batt_Volt_Min:double|Press_Avg:long|Temp_C80_Avg:double|Temp_C15_Avg:double|Hum_Avg:double\n",
+      "--------------+-----------+-----------------------+-----------------------+------------------------------+-----------------------+------------------------+------------------------+-------------------------------+------------------------+-----------------------+-----------------------+------------------------------+-----------------------+------------------------+------------------------+-------------------------------+------------------------+-----------------------+-----------------------+------------------------------+-----------------------+------------------------+------------------------+-------------------------------+------------------------+-----------------------+-----------------------+------------------------------+-----------------------+------------------------+------------------------+-------------------------------+------------------------+------------------------+------------------------+------------------------+------------------------+------------------------+------------------------+--------------------+--------------+-------------------+-------------------+--------------\n",
+      "2012-05-31 12:|1          |1.383                  |0.6                    |2.75                          |3.37                   |1.368                   |0.439                   |2.673                          |2.74                    |1.332                  |0.478                  |2.75                          |2.75                   |1.242                   |0.379                   |2.74                           |2.79                    |1.162                  |0.535                  |2.337                         |2.75                   |1.159                   |0.354                   |2.34                           |2.39                    |1.27                   |0.614                  |2.337                         |2.75                   |1.322                   |0.416                   |2.157                          |2.24                    |240.3                   |46.0                    |242.0                   |45.39                   |222.0                   |33.45                   |13.79               |1009          |13.84              |14.08              |65.67         \n",
+      "20:00         |           |                       |                       |                              |                       |                        |                        |                               |                        |                       |                       |                              |                       |                        |                        |                               |                        |                       |                       |                              |                       |                        |                        |                               |                        |                       |                       |                              |                       |                        |                        |                               |                        |                        |                        |                        |                        |                        |                        |                    |              |                   |                   |              \n",
+      "2012-05-31 12:|2          |1.183                  |0.449                  |1.923                         |2.13                   |1.135                   |0.324                   |1.94                           |1.99                    |0.948                  |0.524                  |1.923                         |2.13                   |1.068                   |0.303                   |1.723                          |1.74                    |0.701                  |0.547                  |1.923                         |2.13                   |0.913                   |0.308                   |1.673                          |1.74                    |0.771                  |0.539                  |1.717                         |2.13                   |0.997                   |0.28                    |1.657                          |1.74                    |282.0                   |26.79                   |264.3                   |30.25                   |278.5                   |62.87                   |13.73               |1009          |14.04              |14.45              |64.51         \n",
+      "30:00         |           |                       |                       |                              |                       |                        |                        |                               |                        |                       |                       |                              |                       |                        |                        |                               |                        |                       |                       |                              |                       |                        |                        |                               |                        |                       |                       |                              |                       |                        |                        |                               |                        |                        |                        |                        |                        |                        |                        |                    |              |                   |                   |              \n",
+      "Total count: 2\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "db = \"/tmp/example.db\"\n",
+    "uri = f\"sqlite:///{db}\"\n",
+    "create_sqlite_db(db, content, table=\"sensors\")\n",
+    "\n",
+    "with FugueWorkflow() as dag:\n",
+    "    df = dag.create(load_db, params={\"table\": \"sensors\", \"con\": uri})\n",
+    "    df.show()\n",
+    "\n",
+    "os.unlink(db)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.6 ('fugue')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "787dcf4b06485f091e5ea0894a1563cc39da567670ce0a93adb376c1b3122bd1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hey there,

There's not much to this tutorial, I just demo making a custom creator via `pandas`.  

I imagine the same thing should work via `dask` using `dd.read_sql` or `duckdb` via `postgres`/`sqlite` scanner extensions.  

You mention on the slack using the database engine to export to files, or even to `DataFrame` via something like https://docs.snowflake.com/en/user-guide/python-connector.html - do you think it's worth demoing or mentioning? 