### PR TITLE
Reducing build time by building sphinx

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Fugue Tutorials
 author: The Fugue Development Team
 logo: images/logo_blue.svg
 execute:
-  timeout: 1200
+  timeout: 600
   execute_notebooks: off
   allow_errors: false
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Fugue Tutorials
 author: The Fugue Development Team
 logo: images/logo_blue.svg
 execute:
-  timeout: 600
+  timeout: 1200
   execute_notebooks: off
   allow_errors: false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ pytest
 pytest-cov
 pytest-mock
 pytest-spark
-sphinx
+sphinx~=4.0
 myst-parser>=0.15
-myst-nb>=0.13.1
+myst-nb~=0.13.1
 
 nbconvert>=6.5.0
 nbsphinx>=0.8.6

--- a/tutorials/quick_look/ten_minutes.ipynb
+++ b/tutorials/quick_look/ten_minutes.ipynb
@@ -1554,7 +1554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
The current docs fail intermittently due to build time. This is because the ReadTheDocs machine resources can vary so the build can be slower. To prevent timeouts, we'll try bumping the build time to 20 mins instead.