### PR TITLE
Quote the install

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ pip install fugue
 Backend engines are installed separately through pip extras. For example, to install Spark:
 
 ```bash
-"pip install fugue[spark]"
+pip install "fugue[spark]"
 ```
 
 If Spark, Dask, or Ray are already installed on your machine, Fugue will be able to detect it. Spark requires Java to be installed separately.

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ pip install fugue
 Backend engines are installed separately through pip extras. For example, to install Spark:
 
 ```bash
-pip install fugue[spark]
+"pip install fugue[spark]"
 ```
 
 If Spark, Dask, or Ray are already installed on your machine, Fugue will be able to detect it. Spark requires Java to be installed separately.


### PR DESCRIPTION
```
pip install fugue[duckdb,spark]
zsh: no matches found: fugue[duckdb,spark]
```

```
pip install "fugue[duckdb,spark]"
Collecting fugue[duckdb,spark]
  Downloading fugue-0.8.3-py3-none-any.whl (372 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 372.4/372.4 kB 8.6 MB/s eta 0:00:00
Collecting adagio>=0.2.4
...
```