### PR TITLE
docs: fix typo Fugue

### DIFF
--- a/tutorials/integrations/backends/ibis.ipynb
+++ b/tutorials/integrations/backends/ibis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fuuge with Ibis\n",
+    "# Fugue with Ibis\n",
     "\n",
     "The [Ibis project](https://ibis-project.org/docs/) tries to bridge the gap between local Python and [various datastore backends](https://ibis-project.org/docs/backends/index.html) including distributed systems such as Spark and Dask. The main idea is to create a pythonic interface to express SQL semantics, so the expression is agnostic to the backends.\n",
     "\n",


### PR DESCRIPTION
Fixed a small typo in the docs.

Fuugu -> Fugue